### PR TITLE
Transform a change by using an undeleted visible cell or by ignoring exact replacements

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -357,8 +357,9 @@ extends Region implements TargetPositionVisitor {
 
     private double distanceFromSky(int itemIndex) {
         C cell = positioner.getVisibleCell(itemIndex);
+        int lastIndex = cellListManager.getLazyCellList().size() - 1;
         return gravity.get() == Gravity.FRONT
-                ? sizeTracker.getViewportLength() - orientation.maxY(cell)
+                ? itemIndex == lastIndex ? 0 : sizeTracker.getViewportLength() - orientation.maxY(cell)
                 : orientation.minY(cell);
     }
 

--- a/src/main/java/org/fxmisc/flowless/TargetPosition.java
+++ b/src/main/java/org/fxmisc/flowless/TargetPosition.java
@@ -62,8 +62,13 @@ final class StartOffStart implements TargetPosition {
             // change before the target item, just update item index
             return new StartOffStart(itemIndex - removedSize + addedSize, offsetFromStart);
         } else if(itemIndex >= pos) {
-            // target item deleted, show the first inserted at the target offset
-            return new StartOffStart(pos, offsetFromStart);
+            // target item deleted
+            if (addedSize == removedSize) {
+                return this;
+            } else {
+                // show the first inserted at the target offset
+                return new StartOffStart(pos, offsetFromStart);
+            }
         } else {
             // change after the target item, target position not affected
             return this;
@@ -119,8 +124,13 @@ final class EndOffEnd implements TargetPosition {
             // change before the target item, just update item index
             return new EndOffEnd(itemIndex - removedSize + addedSize, offsetFromEnd);
         } else if(itemIndex >= pos) {
-            // target item deleted, show the last inserted at the target offset
-            return new EndOffEnd(pos + addedSize - 1, offsetFromEnd);
+            // target item deleted
+            if (addedSize == removedSize) {
+                return this;
+            } else {
+                // show the last inserted at the target offset
+                return new EndOffEnd(pos + addedSize - 1, offsetFromEnd);
+            }
         } else {
             // change after the target item, target position not affected
             return this;
@@ -165,8 +175,13 @@ final class MinDistanceTo implements TargetPosition {
             // change before the target item, just update item index
             return new MinDistanceTo(itemIndex - removedSize + addedSize, minY, maxY);
         } else if(itemIndex >= pos) {
-            // target item deleted, show the first inserted
-            return new MinDistanceTo(pos, Offset.fromStart(0.0), Offset.fromEnd(0.0));
+            // target item deleted
+            if (addedSize == removedSize) {
+                return this;
+            } else {
+                // show the first inserted
+                return new MinDistanceTo(pos, Offset.fromStart(0.0), Offset.fromEnd(0.0));
+            }
         } else {
             // change after the target item, target position not affected
             return this;


### PR DESCRIPTION
Coming from TomasMikula/RichTextFX#390 and #39, the code did not account for the possibility of a deletion that occurs before a StartOffStart's itemIndex and continues into the viewport. Thus, the code before this PR would scroll to the first cell even if this was not desired. This PR fixes the issue. 

However, in the situation where the `removedSize == addedSize`, one does not know whether the offset value should be adjusted to 0.0 or left as is so that the viewport appears not to scroll at all.
Using RichTextFX as an example, if one scrolled the viewport slightly so that the first visible line was only halfway visible before removing some regular text and replacing it with a tall image, should the resulting offset value be 0.0 or left as is? What might prevent undesirable scrolling in one situation may force the same in another.