### PR TITLE
Fix bug: version should only be outputted when task is called

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,5 +57,7 @@ task fatJar(type: Jar, dependsOn: classes) {
 assemble.dependsOn fatJar
 
 task getVersion {
-  println version
+    doLast {
+        println version
+    }
 }


### PR DESCRIPTION
Seems like this is outputted multiple times throughout the project when it should only be outputted when called in Travis.