### PR TITLE
Revert - Add cells under the ground when item index is the last one

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -357,9 +357,8 @@ extends Region implements TargetPositionVisitor {
 
     private double distanceFromSky(int itemIndex) {
         C cell = positioner.getVisibleCell(itemIndex);
-        int lastIndex = cellListManager.getLazyCellList().size() - 1;
         return gravity.get() == Gravity.FRONT
-                ? itemIndex == lastIndex ? 0 : sizeTracker.getViewportLength() - orientation.maxY(cell)
+                ? sizeTracker.getViewportLength() - orientation.maxY(cell)
                 : orientation.minY(cell);
     }
 


### PR DESCRIPTION
Resolves #51. Unfortunately, this does not address the problem the reverted commit fixed: when the horizontal scrollbar is visible and the last cell is visible, then replacing all the cells will cause the viewport to scroll one cell above the last cell, so that the last cell is no longer visible in the viewport.