### PR TITLE
Workaround from @StrangeNoises to correct trackpad scrolling gestures…

### DIFF
--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
+import javafx.scene.input.ScrollEvent;
 
 import org.reactfx.EventStreams;
 import org.reactfx.Subscription;
@@ -18,6 +19,7 @@ import org.reactfx.collection.QuasiListModification;
  */
 final class CellListManager<T, C extends Cell<T, ? extends Node>> {
 
+    private final Node owner;
     private final CellPool<T, C> cellPool;
     private final MemoizationList<C> cells;
     private final LiveList<C> presentCells;
@@ -26,8 +28,10 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
     private final Subscription presentCellsSubscription;
 
     public CellListManager(
+            Node owner,
             ObservableList<T> items,
             Function<? super T, ? extends C> cellFactory) {
+        this.owner = owner;
         this.cellPool = new CellPool<>(cellFactory);
         this.cells = LiveList.map(items, this::cellForItem).memoize();
         this.presentCells = cells.memoizedItems();
@@ -96,7 +100,37 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
         // It will be made visible when it is positioned.
         node.setVisible(false);
 
+        if (cell.isReusable()) {
+            // if cell is reused i think adding event handler
+            // would cause resource leakage.
+            node.setOnScroll(this::pushScrollEvent);
+            node.setOnScrollStarted(this::pushScrollEvent);
+            node.setOnScrollFinished(this::pushScrollEvent);
+        } else {
+            node.addEventHandler(ScrollEvent.ANY, this::pushScrollEvent);
+        }
+
         return cell;
+    }
+
+     /**
+     * Push scroll events received by cell nodes directly to
+     * the 'owner' Node. (Generally likely to be a VirtualFlow
+     * but not required.)
+     *
+     * Normal bubbling of scroll events gets interrupted during
+     * a scroll gesture when the Cell's Node receiving the event
+     * has moved out of the viewport and is thus removed from
+     * the Navigator's children list. This breaks expected trackpad
+     * scrolling behaviour, at least on macOS.
+     * 
+     * So here we take over event-bubbling duties for ScrollEvent
+     * and push them ourselves directly to the given owner.
+     */
+    private void pushScrollEvent(ScrollEvent se) {
+        //Logger.getGlobal().fine(se::toString);
+        owner.fireEvent(se);
+        se.consume();
     }
 
     private void presentCellsChanged(QuasiListModification<? extends C> mod) {

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -168,7 +168,7 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
         this.getStyleClass().add("virtual-flow");
         this.items = items;
         this.orientation = orientation;
-        this.cellListManager = new CellListManager<>(items, cellFactory);
+        this.cellListManager = new CellListManager<>(this, items, cellFactory);
         this.gravity.set(gravity);
         MemoizationList<C> cells = cellListManager.getLazyCellList();
         this.sizeTracker = new SizeTracker(orientation, layoutBoundsProperty(), cells);
@@ -183,7 +183,7 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
         lengthOffsetEstimate = sizeTracker.lengthOffsetEstimateProperty().asVar(this::setLengthOffset);
 
         // scroll content by mouse scroll
-        this.addEventHandler(ScrollEvent.SCROLL, se -> {
+        this.addEventHandler(ScrollEvent.ANY, se -> {
             scrollXBy(-se.getDeltaX());
             scrollYBy(-se.getDeltaY());
             se.consume();


### PR DESCRIPTION
… under macOS (at least).

CellListManager takes responsibility for pushing ScrollEvents to the owning VirtualFlow, bypassing normal event bubbling that fails when Cell Nodes still receive ScrollEvents after being cropped by their Parent Navigator.