### PR TITLE
Add accessors for the index of the first and last visible cell.

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -101,13 +101,12 @@ extends Region implements TargetPositionVisitor {
     }
 
     private TargetPosition getCurrentPosition() {
-        OptionalInt firstVisible = positioner.getFirstVisibleIndex();
-        if(firstVisible.isPresent()) {
-            int idx = firstVisible.getAsInt();
-            C cell = positioner.getVisibleCell(idx);
-            return new StartOffStart(idx, orientation.minY(cell));
-        } else {
+        if (cellListManager.getLazyCellList().getMemoizedCount() == 0) {
             return TargetPosition.BEGINNING;
+        }
+        else {
+            C cell = positioner.getVisibleCell(firstVisibleIndex);
+            return new StartOffStart(firstVisibleIndex, orientation.minY(cell));
         }
     }
 

--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -36,6 +36,8 @@ extends Region implements TargetPositionVisitor {
 
     private TargetPosition currentPosition = TargetPosition.BEGINNING;
     private TargetPosition targetPosition = TargetPosition.BEGINNING;
+    private int firstVisibleIndex = -1;
+    private int lastVisibleIndex = -1;
 
     public Navigator(
             CellListManager<T, C> cellListManager,
@@ -179,6 +181,24 @@ extends Region implements TargetPositionVisitor {
         fillViewportFrom(targetPosition.itemIndex);
     }
 
+    /**
+     * Get the index of the first visible cell (at the time of the last layout).
+     * 
+     * @return The index of the first visible cell
+     */
+    public int getFirstVisibleIndex() {
+        return firstVisibleIndex;
+    }
+    
+    /**
+     * Get the index of the last visible cell (at the time of the last layout).
+     * 
+     * @return The index of the last visible cell
+     */
+    public int getLastVisibleIndex() {
+        return lastVisibleIndex;
+    }
+    
     private void placeToViewport(int itemIndex, Offset from, Offset to) {
         C cell = positioner.getVisibleCell(itemIndex);
         double fromY = from.isFromStart()
@@ -327,6 +347,8 @@ extends Region implements TargetPositionVisitor {
                 orientation.minY(positioner.getVisibleCell(last)) >= sizeTracker.getViewportLength()) {
             --last;
         }
+        firstVisibleIndex = first;
+        lastVisibleIndex = last;
         positioner.cropTo(first, last + 1);
     }
 

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -407,11 +407,11 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
 
         layout();
 
-        int firstVisible = cellPositioner.getFirstVisibleIndex().getAsInt();
+        int firstVisible = getFirstVisibleIndex();
         firstVisible = navigator.fillBackwardFrom0(firstVisible, lOff);
         C firstCell = cellPositioner.getVisibleCell(firstVisible);
 
-        int lastVisible = cellPositioner.getLastVisibleIndex().getAsInt();
+        int lastVisible = getLastVisibleIndex();
         lastVisible = navigator.fillForwardFrom0(lastVisible, lOff);
         C lastCell = cellPositioner.getVisibleCell(lastVisible);
 

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -488,6 +488,24 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
       showBreadthRegion(orientation.minX(region), orientation.maxX(region));
     }
 
+    /**
+     * Get the index of the first visible cell (at the time of the last layout).
+     * 
+     * @return The index of the first visible cell
+     */
+    public int getFirstVisibleIndex() {
+        return navigator.getFirstVisibleIndex();
+    }
+    
+    /**
+     * Get the index of the last visible cell (at the time of the last layout).
+     * 
+     * @return The index of the last visible cell
+     */
+    public int getLastVisibleIndex() {
+        return navigator.getLastVisibleIndex();
+    }
+    
     private void showBreadthRegion(double fromX, double toX) {
         double bOff = breadthOffset0.getValue();
         double spaceBefore = fromX - bOff;

--- a/src/test/java/org/fxmisc/flowless/VirtualFlowTest.java
+++ b/src/test/java/org/fxmisc/flowless/VirtualFlowTest.java
@@ -1,14 +1,16 @@
 package org.fxmisc.flowless;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.shape.Rectangle;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class VirtualFlowTest {
 
@@ -47,4 +49,35 @@ public class VirtualFlowTest {
         assertEquals(-10.0, rect.getBoundsInParent().getMinY(), 0.01);
     }
 
+    @Test
+    public void fastVisibleIndexTest() {
+        ObservableList<Rectangle> items = FXCollections.observableArrayList();
+        for (int i = 0; i < 100; i++) {
+            items.add(new Rectangle(500, 100));
+        }
+
+        VirtualFlow<Rectangle, Cell<Rectangle, Rectangle>> vf = VirtualFlow.createVertical(items, Cell::wrapNode);
+        vf.resize(100, 450); // size of VirtualFlow enough to show several cells
+        vf.layout();
+
+        ObservableList<Cell<Rectangle,Rectangle>> visibleCells = vf.visibleCells();
+        
+        vf.show(0);
+        vf.layout();
+        assertSame(visibleCells.get(0), vf.getCell(vf.getFirstVisibleIndex()));
+        assertSame(visibleCells.get(visibleCells.size() - 1), vf.getCell(vf.getLastVisibleIndex()));
+        assertTrue(vf.getFirstVisibleIndex() <= 0 && 0 <= vf.getLastVisibleIndex());
+        
+        vf.show(50);
+        vf.layout();
+        assertSame(visibleCells.get(0), vf.getCell(vf.getFirstVisibleIndex()));
+        assertSame(visibleCells.get(visibleCells.size() - 1), vf.getCell(vf.getLastVisibleIndex()));
+        assertTrue(vf.getFirstVisibleIndex() <= 50 && 50 <= vf.getLastVisibleIndex());
+
+        vf.show(99);
+        vf.layout();
+        assertSame(visibleCells.get(0), vf.getCell(vf.getFirstVisibleIndex()));
+        assertSame(visibleCells.get(visibleCells.size() - 1), vf.getCell(vf.getLastVisibleIndex()));
+        assertTrue(vf.getFirstVisibleIndex() <= 99 && 99 <= vf.getLastVisibleIndex());
+    }
 }


### PR DESCRIPTION
Save the index of the first and last visible cell at layout time, and
make them available via accessors. This allows much more efficient
retrieval of this information.