### PR TITLE
Fix cells larger than viewport layout efficiency

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -127,14 +127,22 @@ extends Region implements TargetPositionVisitor {
 
     @Override
     public void visit(StartOffStart targetPosition) {
-        placeStartAtMayCrop(targetPosition.itemIndex, targetPosition.offsetFromStart);
+        cropToNeighborhoodOf( targetPosition.itemIndex );  // Fix for issue #70 (!)
+        positioner.placeStartAt( targetPosition.itemIndex, targetPosition.offsetFromStart );
         fillViewportFrom(targetPosition.itemIndex);
     }
 
     @Override
     public void visit(EndOffEnd targetPosition) {
-        placeEndOffEndMayCrop(targetPosition.itemIndex, targetPosition.offsetFromEnd);
+        cropToNeighborhoodOf( targetPosition.itemIndex );  // Related to issue #70 (?)
+        positioner.placeEndFromEnd( targetPosition.itemIndex, targetPosition.offsetFromEnd );
         fillViewportFrom(targetPosition.itemIndex);
+    }
+
+    private void cropToNeighborhoodOf( int itemIndex ) {
+        int begin = Math.max( 0, getFirstVisibleIndex() );
+        int end = Math.max( itemIndex, getLastVisibleIndex() );
+        positioner.cropTo( Math.min( begin, itemIndex ), end+1 );
     }
 
     @Override

--- a/src/test/java/org/fxmisc/flowless/BigCellCreationAndLayoutEfficiencyTest.java
+++ b/src/test/java/org/fxmisc/flowless/BigCellCreationAndLayoutEfficiencyTest.java
@@ -1,0 +1,49 @@
+package org.fxmisc.flowless;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BigCellCreationAndLayoutEfficiencyTest extends FlowlessTestBase {
+
+    private ObservableList<String> items;
+    private Counter cellCreations = new Counter();
+    private VirtualFlow<String, ?> flow;
+
+    @Override
+    public void start(Stage stage) {
+        // set up items
+        items = FXCollections.observableArrayList();
+        items.addAll("red", "green", "blue", "purple");
+
+        // set up virtual flow
+        flow = VirtualFlow.createVertical(
+                items,
+                color -> {
+                    cellCreations.inc();
+                    Region reg = new Region();
+                    reg.setStyle("-fx-background-color: " + color);
+                    if ( color.equals( "purple" ) ) reg.setPrefHeight(500.0);
+                    else reg.setPrefHeight(100.0);
+                    return Cell.wrapNode(reg);
+                });
+
+        StackPane stackPane = new StackPane(flow);
+        stage.setScene(new Scene(stackPane, 200, 400));
+        stage.show();
+    }
+
+    @Test // Relates to issue #70
+    public void having_a_very_tall_item_in_viewport_only_creates_and_lays_out_cell_once() {
+    	// if this fails then it's probably because the very big purple cell is being created multiple times
+        assertEquals(4, cellCreations.get());
+    }
+
+}


### PR DESCRIPTION
Fixes #70 where when a cell is very tall, specifically when it's taller than the view-port, AND some view update occurs then an unnecessary recreation of cells occur which resets the view and doesn't show the update.