### PR TITLE
Scrollbars height/width need to be ceiled to the nearest pixel if this region's snapToPixel property is true.

### DIFF
--- a/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
@@ -269,12 +269,12 @@ public class VirtualizedScrollPane<V extends Node & Virtualized> extends Region 
 
     @Override
     protected void layoutChildren() {
-        double layoutWidth = getLayoutBounds().getWidth();
-        double layoutHeight = getLayoutBounds().getHeight();
+        double layoutWidth = snapSize(getLayoutBounds().getWidth());
+        double layoutHeight = snapSize(getLayoutBounds().getHeight());
         boolean vbarVisible = vbar.isVisible();
         boolean hbarVisible = hbar.isVisible();
-        double vbarWidth = vbarVisible ? vbar.prefWidth(-1) : 0;
-        double hbarHeight = hbarVisible ? hbar.prefHeight(-1) : 0;
+        double vbarWidth = snapSize(vbarVisible ? vbar.prefWidth(-1) : 0);
+        double hbarHeight = snapSize(hbarVisible ? hbar.prefHeight(-1) : 0);
 
         double w = layoutWidth - vbarWidth;
         double h = layoutHeight - hbarHeight;


### PR DESCRIPTION
Fixes #81  Scrollbars height/width need to be ceiled to the nearest pixel if this region's snapToPixel property is true.

Failing to do so will ultimately cause a feedback loop in the layout of the VirtualizedScrollPane under under some screen scale (125%, 150%, 175%, etc...) when used with OpenJFX 16 or higher.
