### PR TITLE
Fix for negative `toItem` variable

### DIFF
--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -84,7 +84,7 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
      */
     public void cropTo(int fromItem, int toItem) {
         fromItem = Math.max(fromItem, 0);
-        toItem = Math.min(toItem, cells.size());
+        toItem = Math.max(Math.min(toItem, cells.size()), 0);
         cells.forget(0, fromItem);
         cells.forget(toItem, cells.size());
     }


### PR DESCRIPTION
Sometimes when I'm using lastest RichTextFx, when I select all text in editor, and cut it (ctrl+x), there is throw exception because of negative `toItem` variable.

This solution probably is not perfect, but it solve this problem.

I see also here "validation" to not pass values bigger than `cells.size()`, so adding validations to not pass values lower then 0 make also sense.

Here is a stacktrace for this exception:
```
Exception in thread "JavaFX Application Thread" java.lang.IndexOutOfBoundsException: [-2147483648, 1) is not a valid range within [0, 1)
	at org.reactfx.util.Lists.checkRange(Lists.java:128)
	at org.reactfx.util.Lists.checkRange(Lists.java:123)
	at org.reactfx.collection.MemoizationListImpl.forget(MemoizationList.java:184)
	at org.fxmisc.flowless.CellListManager.cropTo(CellListManager.java:86)
	at org.fxmisc.flowless.CellPositioner.cropTo(CellPositioner.java:29)
	at org.fxmisc.flowless.Navigator.cropToNeighborhoodOf(Navigator.java:254)
	at org.fxmisc.flowless.Navigator.placeStartAtMayCrop(Navigator.java:227)
	at org.fxmisc.flowless.Navigator.visit(Navigator.java:182)
	at org.fxmisc.flowless.MinDistanceTo.accept(TargetPosition.java:198)
	at org.fxmisc.flowless.Navigator.layoutChildren(Navigator.java:80)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1207)
	at org.fxmisc.flowless.VirtualFlow.layoutChildren(VirtualFlow.java:257)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1207)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Scene.doLayoutPass(Scene.java:576)
	at javafx.graphics/javafx.scene.Scene$ScenePulseListener.pulse(Scene.java:2476)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.lambda$runPulse$2(Toolkit.java:413)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.runPulse(Toolkit.java:412)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.firePulse(Toolkit.java:439)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:563)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:543)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulseFromQueue(QuantumToolkit.java:536)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.lambda$runToolkit$11(QuantumToolkit.java:342)
	at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run$$$capture(InvokeLaterDispatcher.java:96)
	at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:831)
```