### PR TITLE
Crop cells only if memorizedRange is bigger than expected range

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Flowless
 
 Efficient VirtualFlow for JavaFX. VirtualFlow is a layout container that lays out _cells_ in a vertical or horizontal _flow_. The main feature of a _virtual_ flow is that only the currently visible cells are rendered in the scene. You may have a list of thousands of items, but only, say, 30 cells are rendered at any given time.
 
-JavaFX has its own VirtualFlow, which is not part of the public API, but is used, for example, in the implementation of [ListView](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/ListView.html). It is, however, [not very efficient](https://javafx-jira.kenai.com/browse/RT-35395) when updating the viewport on items changed or scroll.
+JavaFX has its own VirtualFlow, which is not part of the public API, but is used, for example, in the implementation of [ListView](https://api.javafx.dev/javafx.controls/javafx/scene/control/ListView.html). It is, however, [not very efficient](https://bugs.openjdk.java.net/browse/JDK-8091726) when updating the viewport on items changed or scroll.
 
 Here is a comparison of JavaFX's ListView vs. Flowless on a list of 80 items, 25 of which fit into the viewport.
 
 |                                              | Flowless (# of cell creations / # of cell layouts) | JDK 8u40 ListView (# of `updateItem` calls / # of cell layouts) | JDK 16 ListView with fixed cell size (# of `updateItem` calls / # of cell layouts) |
 |----------------------------------------------|:-----:|:-----:|:-----:|
-| update an item in the viewport               |   1/1 | 1/1   | 1/25  |
+| update an item in the viewport               |   1/1 | 1/1   | 1/1   |
 | update an item outside the viewport          |   0/0 | 0/0   | 0/0   |
 | delete an item in the middle of the viewport |   1/1 | 38/25 | 13/13 |
 | add an item in the middle of the viewport    |   1/1 | 38/25 | 13/13 |
@@ -22,7 +22,7 @@ Here is the [source code](https://gist.github.com/TomasMikula/1dcee2cc4e5dab4219
 Use case for Flowless
 ---------------------
 
-You will benefit from Flowless (compared to ListView) the most if you have many item updates and an expensive [updateItem](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/Cell.html#updateItem-T-boolean-) method.
+You will benefit from Flowless (compared to ListView) the most if you have many add/delete items occuring in the viewport and an expensive [updateItem](https://api.javafx.dev/javafx.controls/javafx/scene/control/Cell.html#updateItem(T,boolean)) method.
 
 Note, however, that Flowless is a low-level layout component and does not provide higher-level features like selection model or inline editing. One can, of course, implement those on top of Flowless.
 
@@ -46,7 +46,7 @@ VirtualFlow in Flowless provides additional public API compared to ListView or V
 Conceptual differences from ListView
 ------------------------------------
 
-**Dumb cells.** This is the most important difference. For Flowless, cells are just [Node](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/Node.html)s and don't encapsulate any logic regarding virtual flow. A cell does not even necessarily store the index of the item it is displaying. This allows VirtualFlow to have complete control over when the cells are created and/or updated.
+**Dumb cells.** This is the most important difference. For Flowless, cells are just [Node](https://api.javafx.dev/javafx.graphics/javafx/scene/Node.html)s and don't encapsulate any logic regarding virtual flow. A cell does not even necessarily store the index of the item it is displaying. This allows VirtualFlow to have complete control over when the cells are created and/or updated.
 
 **Cell reuse is opt-in,** not forced. Cells are not reused by default. A new cell is created for each item. This simplifies cell implementation and does not impair performance if reusing a cell would be about as expensive as creating a new one (i.e. `updateItem` would be expensive).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here is a comparison of JavaFX's ListView vs. Flowless on a list of 80 items, 25
 | scroll 50 items down                         | 25/25 | 50/25 | 25/25 |
 
 
-Here is the [source code](https://gist.github.com/TomasMikula/1dcee2cc4e5dab421913) of this mini-benchmark.
+Here is the [source code](https://gist.github.com/Jugen/2d392fd72ebec9db3c5d2aca1f8f5eb5) of this mini-benchmark.
 
 Use case for Flowless
 ---------------------

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ Flowless
 
 Efficient VirtualFlow for JavaFX. VirtualFlow is a layout container that lays out _cells_ in a vertical or horizontal _flow_. The main feature of a _virtual_ flow is that only the currently visible cells are rendered in the scene. You may have a list of thousands of items, but only, say, 30 cells are rendered at any given time.
 
-JavaFX has its own VirtualFlow, which is not part of the public API, but is used, for example, in the implementation of [ListView](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/ListView.html). It is, however, [not very efficient](https://javafx-jira.kenai.com/browse/RT-35395) when updating the viewport on items change or scroll.
+JavaFX has its own VirtualFlow, which is not part of the public API, but is used, for example, in the implementation of [ListView](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/ListView.html). It is, however, [not very efficient](https://javafx-jira.kenai.com/browse/RT-35395) when updating the viewport on items changed or scroll.
 
 Here is a comparison of JavaFX's ListView vs. Flowless on a list of 80 items, 25 of which fit into the viewport.
 
-|                                              | Flowless (# of cell creations / # of cell layouts) | JDK 8u40 ListView (# of `updateItem` calls / # of cell layouts) | JDK 8u40 ListView with fixed cell size (# of `updateItem` calls / # of cell layouts) |
+|                                              | Flowless (# of cell creations / # of cell layouts) | JDK 8u40 ListView (# of `updateItem` calls / # of cell layouts) | JDK 16 ListView with fixed cell size (# of `updateItem` calls / # of cell layouts) |
 |----------------------------------------------|:-----:|:-----:|:-----:|
-| update an item in the viewport               |   1/1 | 1/1   | 1/1   |
+| update an item in the viewport               |   1/1 | 1/1   | 1/25  |
 | update an item outside the viewport          |   0/0 | 0/0   | 0/0   |
-| delete an item in the middle of the viewport |   1/1 | 38/25 | 38/25 |
-| add an item in the middle of the viewport    |   1/1 | 38/25 | 38/25 |
+| delete an item in the middle of the viewport |   1/1 | 38/25 | 13/13 |
+| add an item in the middle of the viewport    |   1/1 | 38/25 | 13/13 |
 | scroll 5 items down                          |   5/5 | 5/5   | 5/5   |
 | scroll 50 items down                         | 25/25 | 50/25 | 25/25 |
 

--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
+import javafx.scene.control.IndexRange;
 import javafx.scene.input.ScrollEvent;
 
 import org.reactfx.EventStreams;
@@ -85,8 +86,13 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
     public void cropTo(int fromItem, int toItem) {
         fromItem = Math.max(fromItem, 0);
         toItem = Math.max(Math.min(toItem, cells.size()), 0);
-        cells.forget(0, fromItem);
-        cells.forget(toItem, cells.size());
+        IndexRange memorizedRange = cells.getMemoizedItemsRange();
+        if (memorizedRange.getStart() < fromItem) {
+            cells.forget(0, fromItem);
+        }
+        if (memorizedRange.getEnd() > toItem) {
+            cells.forget(toItem, cells.size());
+        }
     }
 
     private C cellForItem(T item) {

--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -84,7 +84,7 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
      */
     public void cropTo(int fromItem, int toItem) {
         fromItem = Math.max(fromItem, 0);
-        toItem = Math.min(toItem, cells.size());
+        toItem = Math.max(Math.min(toItem, cells.size()), 0);
         cells.forget(0, fromItem);
         cells.forget(toItem, cells.size());
     }


### PR DESCRIPTION
When I added `VirtualFlow.visibleCells()` listener I'm receiving not ending stream of events, but visible cells list is not changing.
The problem seemed to only affect lists where the cell is higher than the visible area (Maybe related to https://github.com/FXMisc/Flowless/pull/80).
```
VirtualFlow<T, C> view = ...;
//.....
view.visibleCells().addListener(new InvalidationListener() {
    @Override
    public void invalidated(Observable observable) {
        System.out.println("a"); // <--- Not ending stream of events (printing `a`).
    }
});
```

I think the problem may be in package `org.reactfx:reactfx:2.0-M5`: `MemorizationListImpl.forget(int from, int to)`
https://github.com/TomasMikula/ReactFX/blob/537fffdbb2958a77dfbca08b712bb2192862e960/reactfx/src/main/java/org/reactfx/collection/MemoizationList.java#L176

It publish events (`memoizedItems.fireRemoveRange(memoChangeFrom, memoRemoved)`) even if `memoRemoved` list is empty.

I'm not sure if this behavior in `reactfx` is good or wrong, but I found workaround to apply in `Flowless` in `CellListManager.cropTo(...)` to `forget` items only when `memorizedRange` is bigger then our `fromItem`-`toItem` range.
