### PR TITLE
Replaced bindBidirectional calls by a pair of ChangeListener to bind scrollbar coordinates and content position.

### DIFF
--- a/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
@@ -92,8 +92,10 @@ public class VirtualizedScrollPane<V extends Node & Virtualized> extends Region 
                 .asVar(this::setVPosition);
         hbarValue = Var.doubleVar(hbar.valueProperty());
         vbarValue = Var.doubleVar(vbar.valueProperty());
-        Bindings.bindBidirectional(hbarValue, hPosEstimate);
-        Bindings.bindBidirectional(vbarValue, vPosEstimate);
+        hbarValue.addListener((observable, oldValue, newValue) -> hPosEstimate.setValue(newValue));
+        hPosEstimate.addListener((observable, oldValue, newValue) -> hbarValue.setValue(newValue));
+        vbarValue.addListener((observable, oldValue, newValue) -> vPosEstimate.setValue(newValue));
+        vPosEstimate.addListener((observable, oldValue, newValue) -> vbarValue.setValue(newValue));
 
         // scrollbar visibility
         hbarPolicy = Var.newSimpleVar(hPolicy);


### PR DESCRIPTION
This PR addresses issue #97

It replaces bindBidirectional calls by a pair of ChangeListener to bind scrollbar coordinates and content position.
This is needed because original solution  no longer works after https://bugs.openjdk.java.net/browse/JDK-8264770