### PR TITLE
compile is removed from Gradle, changed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Flowless
 ========
 
-Please note that as from version **0.6.5** Flowless requires Java **9**.
+Please note that as from version **0.6.5** Flowless requires Java 9 or newer.
 
 Efficient VirtualFlow for JavaFX. VirtualFlow is a layout container that lays out _cells_ in a vertical or horizontal _flow_. The main feature of a _virtual_ flow is that only the currently visible cells are rendered in the scene. You may have a list of thousands of items, but only, say, 30 cells are rendered at any given time.
 
@@ -81,7 +81,7 @@ Include Flowless in your project
 
 ```groovy
 dependencies {
-    compile group: 'org.fxmisc.flowless', name: 'flowless', version: '0.6.7'
+    implementation group: 'org.fxmisc.flowless', name: 'flowless', version: '0.6.7'
 }
 ```
 


### PR DESCRIPTION
`implementation` is used now