### PR TITLE
Fix first cell not showing sometimes

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Navigator.java
+++ b/src/main/java/org/fxmisc/flowless/Navigator.java
@@ -146,6 +146,8 @@ extends Region implements TargetPositionVisitor {
         int begin = Math.max( 0, getFirstVisibleIndex() );
         int end = Math.max( itemIndex, getLastVisibleIndex() );
         positioner.cropTo( Math.min( begin, itemIndex ), end+1 );
+        // Needed for correct layout in some situations
+        sizeTracker.getAverageLengthEstimate();
     }
 
     @Override

--- a/src/test/java/org/fxmisc/flowless/FirstCellCreationAndLayoutTest.java
+++ b/src/test/java/org/fxmisc/flowless/FirstCellCreationAndLayoutTest.java
@@ -1,0 +1,33 @@
+package org.fxmisc.flowless;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.Label;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FirstCellCreationAndLayoutTest extends FlowlessTestBase
+{
+    private VirtualFlow<Label, ?> flow;
+
+    @Override
+    public void start(Stage stage)
+    {
+    	Label first = new Label( "First Item" );
+    	Label second = new Label( "Second Item" );
+        ObservableList<Label> items = FXCollections.observableArrayList( first, second );
+        flow = VirtualFlow.createVertical( items, Cell::wrapNode );
+
+        stage.setScene( new Scene( flow, 200, 100 ) );
+        stage.show();
+    }
+
+    @Test
+    public void does_the_first_cell_layout_correctly()
+    {
+        assertEquals( 0, flow.getFirstVisibleIndex() );
+    }
+}


### PR DESCRIPTION
Under certain conditions the first cell would not be placed and rendered, but only the second cell and up.

This bug was introduced by PR #80 where `Navigation.visit(StartOffStart)` was changed to call a new method instead of `placeStartAtMayCrop`. The latter however was invoking `getAverageLengthEstimate`, which appears to be a necessary call in some layout scenarios. So this PR reintroduces a call to it and provides a test case.
