### PR TITLE
Fix for scrolling content

### DIFF
--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -523,7 +523,7 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
         double total = totalLengthEstimateProperty().getOrElse(0.0);
         double length = sizeTracker.getViewportLength();
         double max = Math.max(total - length, 0);
-        double current = lengthOffsetEstimate.getValue();
+        double current = Math.round(lengthOffsetEstimate.getValue());
 
         if(pixels > max) pixels = max;
         if(pixels < 0) pixels = 0;


### PR DESCRIPTION
Probably, after commit [https://github.com/FXMisc/Flowless/pull/106] I have noticed a negative impact on RichTextFx - during typing text in editor it starts "minimally" scrolling.

I see, that in mentioned commit there is `Math.round(offset)` in `VirtualizedScrollPane`:
```
   private void setVPosition(double pos) {
        // ....
        content.estimatedScrollYProperty().setValue((double) Math.round(offset));
    }
```

But farther, when this action goes to `VirtualFlow` class - to method:
```
void setLengthOffset(double pixels) {
        double total = totalLengthEstimateProperty().getOrElse(0.0);
        double length = sizeTracker.getViewportLength();
        double max = Math.max(total - length, 0);
        double current = lengthOffsetEstimate.getValue();

        if(pixels > max) pixels = max;
        if(pixels < 0) pixels = 0;

        double diff = pixels - current;
        if(diff == 0) {
            // do nothing
        } else if(Math.abs(diff) <= length) { // distance less than one screen
            navigator.scrollCurrentPositionBy(diff);
        } else {
            jumpToAbsolutePosition(pixels);
        }
    }
```
The incoming `pixels` value is rounded, but value in variable `current` is not rounded, and when we compute `diff`:
```
double diff = pixels - current;
```
... there is very often computed value `0.5` (but it should be `0`) and VirtualFlow moves visible content by this `diff` (`navigator.scrollCurrentPositionBy(diff)`) instead of `// do nothing`


My fix here is to apply rounding on `lengthOffsetEstimate`. This solves this issue.

