### PR TITLE
Add item index to Cell creation

### DIFF
--- a/src/main/java/org/fxmisc/flowless/Cell.java
+++ b/src/main/java/org/fxmisc/flowless/Cell.java
@@ -38,13 +38,13 @@ public interface Cell<T, N extends Node> {
      * this method is called to display a different item. {@link #reset()}
      * will have been called before a call to this method.
      *
-     * <p>The default implementation throws
-     * {@link UnsupportedOperationException}.
+     * <p>The default implementation calls {@link #updateItem(Object)}
      *
+     * @param index the item's position in the VirtualFlow list
      * @param item the new item to display
      */
-    default void updateItem(T item) {
-        throw new UnsupportedOperationException();
+    default void update(Integer index, T item) {
+        updateItem(item);
     }
 
     /**
@@ -52,12 +52,13 @@ public interface Cell<T, N extends Node> {
      * this method is called to display a different item. {@link #reset()}
      * will have been called before a call to this method.
      *
-     * <p>The default implementation calls {@link #updateItem(Object)}
+     * <p>The default implementation throws
+     * {@link UnsupportedOperationException}.
      *
      * @param item the new item to display
      */
-    default void updateItem(Integer index, T item) {
-        updateItem(item);
+    default void updateItem(T item) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/org/fxmisc/flowless/Cell.java
+++ b/src/main/java/org/fxmisc/flowless/Cell.java
@@ -48,6 +48,19 @@ public interface Cell<T, N extends Node> {
     }
 
     /**
+     * If this cell is reusable (as indicated by {@link #isReusable()}),
+     * this method is called to display a different item. {@link #reset()}
+     * will have been called before a call to this method.
+     *
+     * <p>The default implementation calls {@link #updateItem(Object)}
+     *
+     * @param item the new item to display
+     */
+    default void updateItem(Integer index, T item) {
+        updateItem(item);
+    }
+
+    /**
      * Called to update index of a visible cell.
      *
      * <p>Default implementation does nothing.

--- a/src/main/java/org/fxmisc/flowless/CellPool.java
+++ b/src/main/java/org/fxmisc/flowless/CellPool.java
@@ -23,8 +23,13 @@ final class CellPool<T, C extends Cell<T, ?>> {
     public C getCell(Integer index, T item) {
         C cell = pool.poll();
         if(cell != null) {
-            cell.updateItem(index, item);
+            // Note that update(index,item) invokes
+        	// cell.updateItem(item) by default
+            cell.update(index, item);
         } else {
+            // Note that cellFactory may just be a wrapper:
+            // (index, item) -> wrappedFactory.apply(item)
+            // See the various VirtualFlow creation methods
             cell = cellFactory.apply(index, item);
         }
         return cell;

--- a/src/main/java/org/fxmisc/flowless/CellPool.java
+++ b/src/main/java/org/fxmisc/flowless/CellPool.java
@@ -2,17 +2,17 @@ package org.fxmisc.flowless;
 
 import java.util.LinkedList;
 import java.util.Queue;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * Helper class that stores a pool of reusable cells that can be updated via {@link Cell#updateItem(Object)} or
  * creates new ones via its {@link #cellFactory} if the pool is empty.
  */
 final class CellPool<T, C extends Cell<T, ?>> {
-    private final Function<? super T, ? extends C> cellFactory;
+    private final BiFunction<Integer, ? super T, ? extends C> cellFactory;
     private final Queue<C> pool = new LinkedList<>();
 
-    public CellPool(Function<? super T, ? extends C> cellFactory) {
+    public CellPool(BiFunction<Integer, ? super T, ? extends C> cellFactory) {
         this.cellFactory = cellFactory;
     }
 
@@ -20,12 +20,12 @@ final class CellPool<T, C extends Cell<T, ?>> {
      * Returns a reusable cell that has been updated with the current item if the pool has one, or returns a
      * newly-created one via its {@link #cellFactory}.
      */
-    public C getCell(T item) {
+    public C getCell(Integer index, T item) {
         C cell = pool.poll();
         if(cell != null) {
-            cell.updateItem(item);
+            cell.updateItem(index, item);
         } else {
-            cell = cellFactory.apply(item);
+            cell = cellFactory.apply(index, item);
         }
         return cell;
     }

--- a/src/main/java/org/fxmisc/flowless/CellPool.java
+++ b/src/main/java/org/fxmisc/flowless/CellPool.java
@@ -24,7 +24,7 @@ final class CellPool<T, C extends Cell<T, ?>> {
         C cell = pool.poll();
         if(cell != null) {
             // Note that update(index,item) invokes
-        	// cell.updateItem(item) by default
+            // cell.updateItem(item) by default
             cell.update(index, item);
         } else {
             // Note that cellFactory may just be a wrapper:

--- a/src/main/java/org/fxmisc/flowless/IndexedMappedList.java
+++ b/src/main/java/org/fxmisc/flowless/IndexedMappedList.java
@@ -1,0 +1,68 @@
+package org.fxmisc.flowless;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.reactfx.Subscription;
+import org.reactfx.collection.LiveList;
+import org.reactfx.collection.LiveListBase;
+import org.reactfx.collection.QuasiListChange;
+import org.reactfx.collection.QuasiListModification;
+import org.reactfx.collection.UnmodifiableByDefaultLiveList;
+import org.reactfx.util.Lists;
+
+import javafx.collections.ObservableList;
+
+public class IndexedMappedList<E,F> extends LiveListBase<F> implements UnmodifiableByDefaultLiveList<F>
+{
+    private final ObservableList<? extends E> source;
+    private final BiFunction<Integer, ? super E, ? extends F> mapper;
+
+    public IndexedMappedList(ObservableList<? extends E> source,
+                             BiFunction<Integer, ? super E, ? extends F> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public F get(int index) {
+        return mapper.apply(index, source.get(index));
+    }
+
+    @Override
+    public int size() {
+        return source.size();
+    }
+
+    @Override
+    protected Subscription observeInputs() {
+        return LiveList.<E>observeQuasiChanges(source, this::sourceChanged);
+    }
+
+    protected void sourceChanged(QuasiListChange<? extends E> change) {
+        notifyObservers(mappedChangeView(change));
+    }
+
+    private QuasiListChange<F> mappedChangeView(QuasiListChange<? extends E> change) {
+        return () -> {
+            List<? extends QuasiListModification<? extends E>> mods = change.getModifications();
+            return Lists.<QuasiListModification<? extends E>, QuasiListModification<F>>mappedView(mods, mod -> new QuasiListModification<>() {
+
+                @Override
+                public int getFrom() {
+                    return mod.getFrom();
+                }
+
+                @Override
+                public int getAddedSize() {
+                    return mod.getAddedSize();
+                }
+
+                @Override
+                public List<? extends F> getRemoved() {
+                    return Lists.mappedView(mod.getRemoved(), elem -> mapper.apply(mod.getFrom(), elem));
+                }
+            });
+        };
+    }
+}

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -99,6 +99,16 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
     }
 
     /**
+     * Creates a viewport that lays out content horizontally from left to right
+     * but with a cellFactory that also receives the item index.
+     */
+    public static <T, C extends Cell<T, ?>> VirtualFlow<T, C> createHorizontal(
+            ObservableList<T> items,
+            BiFunction<Integer, ? super T, ? extends C> cellFactory) {
+        return new VirtualFlow<>(items, cellFactory, new HorizontalHelper(), Gravity.FRONT);
+    }
+
+    /**
      * Creates a viewport that lays out content vertically from top to bottom
      */
     public static <T, C extends Cell<T, ?>> VirtualFlow<T, C> createVertical(

--- a/src/test/java/org/fxmisc/flowless/CellCreationWithIndexTest.java
+++ b/src/test/java/org/fxmisc/flowless/CellCreationWithIndexTest.java
@@ -1,0 +1,86 @@
+package org.fxmisc.flowless;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class CellCreationWithIndexTest extends FlowlessTestBase {
+
+    private ObservableList<String> items;
+    private Counter cellCreations = new Counter();
+    private VirtualFlow<String, ?> flow;
+
+    @Override
+    public void start(Stage stage) {
+        // set up items
+        items = FXCollections.observableArrayList();
+        for(int i = 0; i < 20; ++i) {
+            items.addAll("red", "green", "blue", "purple");
+        }
+
+        // set up virtual flow
+        flow = VirtualFlow.createVertical(
+                items,
+                (index, color) -> {
+                    cellCreations.inc();
+                    Region reg = new Label( "  "+ index +"\t"+ color );
+                    reg.setPrefHeight(16.0);
+                    reg.setStyle("-fx-background-color: " + color);
+                    return Cell.wrapNode(reg);
+                });
+
+        StackPane stackPane = new StackPane();
+        // 25 cells (each 16px high) fit into the viewport
+        stackPane.getChildren().add(flow);
+        stage.setScene(new Scene(stackPane, 200, 400));
+        stage.show();
+    }
+
+    @Before
+    public void setup() {
+        cellCreations.reset();
+    }
+
+    @Test
+    public void updating_an_item_in_viewport_only_creates_cell_once() {
+        // update an item in the viewport
+        interact(() -> items.set(10, "yellow"));
+        assertEquals(1, cellCreations.getAndReset());
+        assertEquals("10", getCellText(10));
+    }
+
+    private String getCellText(int index) {
+    	return ((Label) flow.getCell(index).getNode()).getText().substring(2,4);
+    }
+
+    @Test
+    public void updating_an_item_outside_viewport_does_not_create_cell() {
+        // update an item outside the viewport
+        interact(() -> items.set(30, "yellow"));
+        assertEquals(0, cellCreations.getAndReset());
+    }
+
+    @Test
+    public void deleting_an_item_in_viewport_only_creates_cell_once() {
+        // delete an item in the middle of the viewport
+        interact(() -> items.remove(12));
+        assertEquals(1, cellCreations.getAndReset());
+    }
+
+    @Test
+    public void adding_an_item_in_viewport_only_creates_cell_once() {
+        // add an item in the middle of the viewport
+        interact(() -> items.add(12, "yellow"));
+        assertEquals(1, cellCreations.getAndReset());
+        assertEquals("12", getCellText(12));
+    }
+}

--- a/src/test/java/org/fxmisc/flowless/IndexedMappedListTest.java
+++ b/src/test/java/org/fxmisc/flowless/IndexedMappedListTest.java
@@ -1,0 +1,83 @@
+package org.fxmisc.flowless;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.reactfx.collection.ListModification;
+import org.reactfx.collection.LiveList;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+public class IndexedMappedListTest
+{
+    @Test
+    public void testIndexedList() {
+        ObservableList<String> strings = FXCollections.observableArrayList("1", "22", "333");
+        // Live map receives index,item and returns %d-%d index item
+        LiveList<String> lengths = new IndexedMappedList<>(strings, (index, item) -> String.format("%d-%d", index, item.length()));
+        assertArrayEquals(new String[] {"0-1", "1-2", "2-3"}, lengths.stream().toArray());
+
+        List<String> removed = new ArrayList<>();
+        List<String> added = new ArrayList<>();
+        lengths.observeChanges(ch -> {
+            for(ListModification<? extends String> mod: ch.getModifications()) {
+                removed.addAll(mod.getRemoved());
+                added.addAll(mod.getAddedSubList());
+            }
+        });
+
+        // Set a value in the list and check changes
+        strings.set(1, "4444");
+        assertArrayEquals(new String[] {"0-1", "1-4", "2-3"}, lengths.stream().toArray());
+        assertEquals(Collections.singletonList("1-4"), added);
+        assertEquals(Collections.singletonList("1-2"), removed);
+
+        // Add an entry to the list and check changes
+        strings.add("7777777");
+        assertArrayEquals(new String[] {"0-1", "1-4", "2-3", "3-7"}, lengths.stream().toArray());
+        assertEquals(Arrays.asList("1-4", "3-7"), added);
+        assertEquals(Collections.singletonList("1-2"), removed);
+
+        // Remove an entry to the list and check changes (note that 3-7 becomes 2-7)
+        strings.remove(2);
+        assertArrayEquals(new String[] {"0-1", "1-4", "2-7"}, lengths.stream().toArray());
+        assertEquals(Arrays.asList("1-4", "3-7"), added);
+        assertEquals(Arrays.asList("1-2", "2-3"), removed);
+    }
+
+    @Test
+    public void testLazyIndexedList() {
+        ObservableList<String> strings = FXCollections.observableArrayList("1", "22", "333");
+        IntegerProperty evaluationsCounter = new SimpleIntegerProperty(0);
+        LiveList<String> lengths = new IndexedMappedList<>(strings, (index, elem) -> {
+            evaluationsCounter.set(evaluationsCounter.get() + 1);
+            return String.format("%d-%d", index, elem.length());
+        });
+
+        lengths.observeChanges(ch -> {});
+        strings.remove(1);
+
+        assertEquals(0, evaluationsCounter.get());
+
+        // Get the first element and the counter has increased
+        assertEquals("0-1", lengths.get(0));
+        assertEquals(1, evaluationsCounter.get());
+
+        // Get the second element, it will evaluate one item
+        assertEquals("1-3", lengths.get(1));
+        assertEquals(2, evaluationsCounter.get());
+
+        // Get again the first, it will reevaluate it
+        assertEquals("0-1", lengths.get(0));
+        assertEquals(3, evaluationsCounter.get());
+    }
+}


### PR DESCRIPTION
This PR adds a new VirtualFlow construction method that takes a BiFunction parameter so that the item index is available for the Cell factory.

Issue FXMisc/RichTextFX#1273 refers.