### PR TITLE
Added refreshCells method

### DIFF
--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -82,10 +82,20 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
      * updateItem to be invoked on the next available pooled Cell. If a Cell is
      * not available or reusable, a new Cell is created via the cell factory.
      */
-    public void refreshCell(int itemIndex) {
-        if (itemIndex >= 0 && itemIndex < cells.size() && cells.isMemoized(itemIndex)) {
-            cells.forget(itemIndex, itemIndex+1);
-        }
+    public void refreshCells(int fromItem, int toItem) {
+    	int start = Math.min( fromItem, toItem );
+    	int end = Math.max( fromItem, toItem );
+
+    	IndexRange memorizedRange = cells.getMemoizedItemsRange();
+    	int min = memorizedRange.getStart();
+    	int max = memorizedRange.getEnd();
+
+    	start = Math.max( start, min );
+    	end = Math.min( end, max );
+
+    	if ( start < max && end > min ) {
+    		cells.forget(start, end);
+    	}
     }
 
     /**

--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -81,21 +81,21 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
      * This is a noop on non visible items. For reusable Cells this will cause
      * updateItem to be invoked on the next available pooled Cell. If a Cell is
      * not available or reusable, a new Cell is created via the cell factory.
+     * @param fromItem - the start index, inclusive.
+     * @param toItem - the end index, exclusive.
      */
     public void refreshCells(int fromItem, int toItem) {
-    	int start = Math.min( fromItem, toItem );
-    	int end = Math.max( fromItem, toItem );
+        if (fromItem >= toItem) throw new IllegalArgumentException(
+            String.format("To must be greater than from. from=%s to=%s", fromItem, toItem)
+        );
 
-    	IndexRange memorizedRange = cells.getMemoizedItemsRange();
-    	int min = memorizedRange.getStart();
-    	int max = memorizedRange.getEnd();
+        IndexRange memorizedRange = cells.getMemoizedItemsRange();
+        fromItem = Math.max( fromItem, memorizedRange.getStart() );
+        toItem = Math.min( toItem, memorizedRange.getEnd() );
 
-    	start = Math.max( start, min );
-    	end = Math.min( end, max );
-
-    	if ( start < max && end > min ) {
-    		cells.forget(start, end);
-    	}
+        if (fromItem < toItem) {
+            cells.forget(fromItem, toItem);
+        }
     }
 
     /**

--- a/src/main/java/org/fxmisc/flowless/CellListManager.java
+++ b/src/main/java/org/fxmisc/flowless/CellListManager.java
@@ -78,6 +78,17 @@ final class CellListManager<T, C extends Cell<T, ? extends Node>> {
     }
 
     /**
+     * This is a noop on non visible items. For reusable Cells this will cause
+     * updateItem to be invoked on the next available pooled Cell. If a Cell is
+     * not available or reusable, a new Cell is created via the cell factory.
+     */
+    public void refreshCell(int itemIndex) {
+        if (itemIndex >= 0 && itemIndex < cells.size() && cells.isMemoized(itemIndex)) {
+            cells.forget(itemIndex, itemIndex+1);
+        }
+    }
+
+    /**
      * Updates the list of cells to display
      *
      * @param fromItem the index of the first item to display

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -225,9 +225,11 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
      * This is a noop on non visible items. For reusable Cells this will cause
      * updateItem to be invoked on the next available pooled Cell. If a Cell is
      * not available or reusable, a new Cell is created via the cell factory.
+     * @param fromIndex - the start index, inclusive.
+     * @param toIndex - the end index, exclusive.
      */
     public void refreshCells(int fromIndex, int toIndex) {
-    	cellListManager.refreshCells(fromIndex, toIndex);
+        cellListManager.refreshCells(fromIndex, toIndex);
     }
 
     /**

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -226,8 +226,8 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
      * updateItem to be invoked on the next available pooled Cell. If a Cell is
      * not available or reusable, a new Cell is created via the cell factory.
      */
-    public void refreshCell(int itemIndex) {
-    	cellListManager.refreshCell(itemIndex);
+    public void refreshCells(int fromIndex, int toIndex) {
+    	cellListManager.refreshCells(fromIndex, toIndex);
     }
 
     /**

--- a/src/main/java/org/fxmisc/flowless/VirtualFlow.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualFlow.java
@@ -222,6 +222,15 @@ public class VirtualFlow<T, C extends Cell<T, ?>> extends Region implements Virt
     }
 
     /**
+     * This is a noop on non visible items. For reusable Cells this will cause
+     * updateItem to be invoked on the next available pooled Cell. If a Cell is
+     * not available or reusable, a new Cell is created via the cell factory.
+     */
+    public void refreshCell(int itemIndex) {
+    	cellListManager.refreshCell(itemIndex);
+    }
+
+    /**
      * This method calls {@link #layout()} as a side-effect to insure
      * that the VirtualFlow is up-to-date in light of any changes
      */

--- a/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
+++ b/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
@@ -72,6 +72,14 @@ public class CellCreationAndLayoutEfficiencyTest extends FlowlessTestBase {
     }
 
     @Test
+    public void refreshing_a_cell_in_viewport_creates_and_lays_out_once() {
+        // refresh a cell in the viewport
+        interact(() -> flow.refreshCell(10));
+        assertEquals(1, cellCreations.getAndReset());
+        assertEquals(1, cellLayouts.getAndReset());
+    }
+
+    @Test
     public void deleting_an_item_in_viewport_only_creates_and_lays_out_cell_once() {
         // delete an item in the middle of the viewport
         interact(() -> items.remove(12));

--- a/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
+++ b/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
@@ -78,6 +78,13 @@ public class CellCreationAndLayoutEfficiencyTest extends FlowlessTestBase {
         assertEquals(2, cellCreations.getAndReset());
         assertEquals(2, cellLayouts.getAndReset());
     }
+    @Test
+    public void refreshing_cells_outside_viewport_does_not_create_or_lay_them_out() {
+        // refresh 10 cells, 5 in and 5 outside the viewport
+        interact(() -> flow.refreshCells(20,30));
+        assertEquals(5, cellCreations.getAndReset());
+        assertEquals(5, cellLayouts.getAndReset());
+    }
 
     @Test
     public void deleting_an_item_in_viewport_only_creates_and_lays_out_cell_once() {

--- a/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
+++ b/src/test/java/org/fxmisc/flowless/CellCreationAndLayoutEfficiencyTest.java
@@ -72,11 +72,11 @@ public class CellCreationAndLayoutEfficiencyTest extends FlowlessTestBase {
     }
 
     @Test
-    public void refreshing_a_cell_in_viewport_creates_and_lays_out_once() {
-        // refresh a cell in the viewport
-        interact(() -> flow.refreshCell(10));
-        assertEquals(1, cellCreations.getAndReset());
-        assertEquals(1, cellLayouts.getAndReset());
+    public void refreshing_cells_in_viewport_creates_and_lays_them_out_once() {
+        // refresh cells in the viewport
+        interact(() -> flow.refreshCells(10,12));
+        assertEquals(2, cellCreations.getAndReset());
+        assertEquals(2, cellLayouts.getAndReset());
     }
 
     @Test


### PR DESCRIPTION
This adds the ability to refresh a Cell without updating it's item. This is needed in situations where the context the item is in changes the way it is displayed, without the item itself changing.